### PR TITLE
Fix JSONPath trait not found error

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ece5b8a234c6bb2f982bc52b3069c2b",
+    "content-hash": "6b043984dc64aaff9159544dabca98bd",
     "packages": [
         {
             "name": "softcreatr/jsonpath",

--- a/custom-api-creator.php
+++ b/custom-api-creator.php
@@ -463,7 +463,7 @@ class CAC_Plugin_Class {
 	}
 
 	// Include JSONPath
-	use Flow\JSONPath\JSONPath;
+	use SoftCreatR\JSONPath\JSONPath;
 
 	public function extract_data_with_jsonpath( $json_data, $jsonpath_query ) {
 		// Parse JSON data


### PR DESCRIPTION
Update the `custom-api-creator.php` file to use the correct JSONPath trait.

* Change the `use` statement to `use SoftCreatR\JSONPath\JSONPath;` in `custom-api-creator.php`.
* Update the `composer.lock` file to reflect the correct content hash for the `softcreatr/jsonpath` package.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dexit/wp-custom-api-creator/pull/5?shareId=e9dbc410-609a-44a5-904a-eb511b884c3b).