### PR TITLE
Fix JSONPath trait not found error

### DIFF
--- a/custom-api-creator.php
+++ b/custom-api-creator.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+use SoftCreatR\JSONPath\JSONPath;
+
 class CAC_Plugin_Class {
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_custom_post_type' ) );


### PR DESCRIPTION
Add the `use SoftCreatR\JSONPath\JSONPath;` statement to the `custom-api-creator.php` file.

* Add `use SoftCreatR\JSONPath\JSONPath;` at line 19 in the `custom-api-creator.php` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dexit/wp-custom-api-creator/pull/6?shareId=e7b4b3e0-6e47-4119-a6ad-b64407c82546).